### PR TITLE
Fixes Issue # 11.  Removed numpy import in the static copy of UTM included in shrimpGIS.

### DIFF
--- a/lib/shrimp_gis/utm/conversion.py
+++ b/lib/shrimp_gis/utm/conversion.py
@@ -1,13 +1,11 @@
 from error import OutOfRangeError
 
-# For most use cases in this module, numpy is indistinguishable
-# from math, except it also works on numpy arrays
-try:
-    import numpy as mathlib
-    use_numpy = True
-except ImportError:
-    import math as mathlib
-    use_numpy = False
+# When UTM (which can optionally use numpy == 1.16.6) is used inside ShrimpGIS, 
+# numpy may well be "indistinguishable" from math, but it is not distinguishable
+# from later versions of numpy, e.g. that installed by LadyBug Tools.  JP
+
+import math as mathlib
+use_numpy = False
 
 __all__ = ['to_latlon', 'from_latlon']
 


### PR DESCRIPTION
The fix works!  

~~This is to test the hypothesis that UTM inside ShrimpGIS is importing whichever numpy version it finds installed.  But if this is a later numpy version  than the one UTM optionally requires (v 1.16.6), it raises a curious error, despite correct syntax:~~ 

~~1. Solution exception:unexpected token ‘from’~~

![image](https://user-images.githubusercontent.com/80779630/220386413-832bca18-5110-440e-961c-778a154bc4ee.png)
